### PR TITLE
Fixed specs :)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ActiveRecord::Base
 	acts_as_authentic do |c|
+		c.maintain_sessions = false
 	end
 end

--- a/spec/controllers/overview_controller_spec.rb
+++ b/spec/controllers/overview_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe OverviewController do
   before :each do
-    #activate_authlogic
+    activate_authlogic
   end
 
   describe "GET index" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,6 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
 
   config.before :each do
-    activate_authlogic
+    #activate_authlogic
   end
 end


### PR DESCRIPTION
Automatic session maintenance is a [feature of Authlogic](http://rubydoc.info/github/binarylogic/authlogic/master/Authlogic/ActsAsAuthentic/SessionMaintenance/Config#maintain_sessions-instance_method)

You can turn off the 'automatic login after create' with: `c.maintain_sessions = false`

This is mentioned in the [Authlogic README](https://github.com/binarylogic/authlogic/blob/master/README.rdoc)
(Ctrl+F -> "will automatically log a user in after a successful registration")

'activate_authlogic' is required in the actual controller spec. It doesn't work from the 'RSpec.configure' block because the `@request` hasn't been defined before it runs.

To answer the second part of your question, you should use an Authentication controller, and only test `activate_authlogic` there. 
For your other controllers, you should mock the Session with a 'require_user' method.

[Here are the authlogic macros that we use in our specs](https://github.com/fatfreecrm/fat_free_crm/blob/master/spec/support/auth_macros.rb).
